### PR TITLE
complete get_metadata unit tests

### DIFF
--- a/test/vaporator/metadata_test.exs
+++ b/test/vaporator/metadata_test.exs
@@ -1,0 +1,48 @@
+defmodule Vaporator.DropboxTestTwo do
+  use ExUnit.Case, async: false
+
+  @dbx %Vaporator.Dropbox{
+    access_token: System.get_env("DROPBOX_ACCESS_TOKEN")
+  }
+
+  @test_dir "/test"
+  @test_file "#{@test_dir}/test.txt"
+
+  setup_all do
+    # TODO: Create @test_dir
+    # TODO: Create @test_file
+
+    on_exit fn ->
+      # TODO: Remove @test_dir
+      IO.puts("This will remove @test_dir")
+    end
+  end
+
+  test "get_metadata from dropbox folder that exists" do
+    meta = Vaporator.Cloud.get_metadata(
+      @dbx,
+      @test_dir,
+      %{}
+    )
+    assert meta[".tag"] == "folder"
+  end
+
+  test "get_metadata from dropbox file that exists" do
+    meta = Vaporator.Cloud.get_metadata(
+      @dbx,
+      @test_file,
+      %{}
+    )
+    assert meta[".tag"] == "file"
+  end
+
+  test "get_metadata from dropbox item that doesn't exists" do
+    meta = Vaporator.Cloud.get_metadata(
+      @dbx,
+      "/fake",
+      %{}
+    )
+    assert meta == nil
+  end
+
+end

--- a/test/vaporator/metadata_test.exs
+++ b/test/vaporator/metadata_test.exs
@@ -5,7 +5,7 @@ defmodule Vaporator.DropboxTestTwo do
     access_token: System.get_env("DROPBOX_ACCESS_TOKEN")
   }
 
-  @test_dir "/test"
+  @test_dir "/vaporator/test"
   @test_file "#{@test_dir}/test.txt"
 
   setup_all do


### PR DESCRIPTION
This closes #26 - Update will be required for setup and teardown once create_file and remove_file functions are available.  For now we need to keep a /test dir and /test/test.txt in the dropbox fs