### PR TITLE
Dropbox file remove

### DIFF
--- a/lib/vaporator/cloud.ex
+++ b/lib/vaporator/cloud.ex
@@ -24,6 +24,8 @@ defprotocol Vaporator.CloudFs do
   # Returns:
   #   {:ok, Vaporator.CloudFs.ResultsMeta}
   #     or
+  #   {:error, {:path_not_found, path error (binary)}
+  #     or 
   #   {:error, {:bad_decode, decode error (any)}
   #     or 
   #   {:error, {:bad_status, {:status_code, code (int)}, JSON (Map)}}
@@ -39,12 +41,13 @@ defprotocol Vaporator.CloudFs do
   # - path (binary): Path of file/folder on cloud file system to get
   #     metadata for
   # - args (Map): File-system-specific arguments to pass to the
-  #     underlying subsystem. In a perfect world, this would be
-  #     unnecessary, but "let it fail..." and all that.
+  #     underlying subsystem. 
   # 
   # Returns:
   #   {:ok, Vaporator.CloudFS.Meta}
   #     or
+  #   {:error, {:path_not_found, path error (binary)}
+  #     or 
   #   {:error, {:bad_decode, decode error (any)}
   #     or 
   #   {:error, {:bad_status, {:status_code, code (int)}, JSON (Map)}}
@@ -60,12 +63,15 @@ defprotocol Vaporator.CloudFs do
   # - fs (Vaporator.CloudFs impl): Cloud file system
   # - path (binary): Path of file on cloud file system to download
   # - args (Map): File-system-specific arguments to pass to the
-  #     underlying subsystem. In a perfect world, this would be
-  #     unnecessary, but "let it fail..." and all that.
+  #     underlying subsystem. 
   # 
   # Returns:
   #   {:ok, Vaporator.CloudFs.FileContent}
   #     or
+  #   {:error, {:path_not_found, path error (binary)}
+  #     or 
+  #   {:error, {:bad_decode, decode error (any)}
+  #     or 
   #   {:error, {:bad_status, {:status_code, code (int)}, JSON (Map)}}
   #     or 
   #   {:error, {:unhandled_status, {:status_code, code (int)}, body (binary)}}
@@ -81,8 +87,7 @@ defprotocol Vaporator.CloudFs do
   #     content. If this path ends with a "/" then it should be
   #     treated as a directory in which to place the local_path
   # - args (Map): File-system-specific arguments to pass to the
-  #     underlying subsystem. In a perfect world, this would be
-  #     unnecessary, but "let it fail..." and all that.
+  #     underlying subsystem. 
   # 
   # Returns:
   #   {:ok, Vaporator.CloudFs.FileContent}
@@ -91,6 +96,28 @@ defprotocol Vaporator.CloudFs do
   #     or 
   #   {:error, {:unhandled_status, {:status_code, code (int)}, body (binary)}}
   def file_upload(fs, local_path, fs_path, args \\ %{})
+
+  # Need to be able to remove a file or folder on the cloud file
+  # system.
+  # 
+  # Args:
+  # - fs (Vaporator.CloudFs impl): Cloud file system
+  # - path (binary): Path on cloud file system to remove. 
+  # - args (Map): File-system-specific arguments to pass to the
+  #     underlying subsystem. 
+  # 
+  # Returns:
+  #   {:ok, Vaporator.CloudFs.FileContent}
+  #     or
+  #   {:error, {:path_not_found, path error (binary)}
+  #     or 
+  #   {:error, {:bad_decode, decode error (any)}
+  #     or 
+  #   {:error, {:bad_status, {:status_code, code (int)}, JSON (Map)}}
+  #     or 
+  #   {:error, {:unhandled_status, {:status_code, code (int)}, body (binary)}}
+  def file_remove(fs, path, args \\ %{})
+  def folder_remove(fs, path, args \\ %{})
 end
 
 defmodule Vaporator.CloudFs.Meta do
@@ -99,9 +126,9 @@ defmodule Vaporator.CloudFs.Meta do
   """
   # Every file on any file-system (Dropbox, GDrive, S3, etc.) should
   # have at least these attributes
-  @enforce_keys [:type, :name, :path]
+  @enforce_keys [:type, :path]
   defstruct [
-    :type,                      # :file or :folder?
+    :type,                      # :file, :folder, or :none?
 
     :name,                      # file name (w/o path)
 

--- a/mix.exs
+++ b/mix.exs
@@ -35,6 +35,7 @@ defmodule Vaporator.MixProject do
       {:httpoison, "~> 1.5.0"},
       {:poison, "~> 4.0.1"},
       {:json, "~> 1.2.1"},
+      {:timex, "~> 3.1"},
       {:excoveralls, "~> 0.10", only: :test},
       {:exvcr, "~> 0.10", only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,11 @@
 %{
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm"},
   "exactor": {:hex, :exactor, "2.2.4", "5efb4ddeb2c48d9a1d7c9b465a6fffdd82300eb9618ece5d34c3334d5d7245b1", [:mix], [], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.10.4", "b86230f0978bbc630c139af5066af7cd74fd16536f71bc047d1037091f9f63a9", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "exjsx": {:hex, :exjsx, "4.0.0", "60548841e0212df401e38e63c0078ec57b33e7ea49b032c796ccad8cde794b5c", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, repo: "hexpm", optional: false]}], "hexpm"},
   "exvcr": {:hex, :exvcr, "0.10.3", "1ae3b97560430acfa88ebc737c85b2b7a9dbacd8a2b26789a19718b51ae3522c", [:mix], [{:exactor, "~> 2.2", [hex: :exactor, repo: "hexpm", optional: false]}, {:exjsx, "~> 4.0", [hex: :exjsx, repo: "hexpm", optional: false]}, {:httpoison, "~> 1.0", [hex: :httpoison, repo: "hexpm", optional: true]}, {:httpotion, "~> 3.1", [hex: :httpotion, repo: "hexpm", optional: true]}, {:ibrowse, "~> 4.4", [hex: :ibrowse, repo: "hexpm", optional: true]}, {:meck, "~> 0.8", [hex: :meck, repo: "hexpm", optional: false]}], "hexpm"},
+  "gettext": {:hex, :gettext, "0.16.1", "e2130b25eebcbe02bb343b119a07ae2c7e28bd4b146c4a154da2ffb2b3507af2", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.0", "287a5d2304d516f63e56c469511c42b016423bcb167e61b611f6bad47e3ca60e", [:rebar3], [{:certifi, "2.4.2", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.5.0", "71ae9f304bdf7f00e9cd1823f275c955bdfc68282bc5eb5c85c3a9ade865d68e", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
@@ -16,5 +18,7 @@
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
+  "timex": {:hex, :timex, "3.5.0", "b0a23167da02d0fe4f1a4e104d1f929a00d348502b52432c05de875d0b9cffa5", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
+  "tzdata": {:hex, :tzdata, "0.5.19", "7962a3997bf06303b7d1772988ede22260f3dae1bf897408ebdac2b4435f4e6a", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/vaporator/dropbox_file_remove.exs
+++ b/test/vaporator/dropbox_file_remove.exs
@@ -1,0 +1,25 @@
+defmodule Vaporator.DropboxFileRemoveTest do
+  use ExUnit.Case
+
+  @dbx %Vaporator.Dropbox{access_token: System.get_env("DROPBOX_ACCESS_TOKEN")}
+
+  setup_all do
+    {:ok, fp} = File.open("./remove-test.txt", [:write])
+    IO.binwrite(fp, "upload test data")
+    File.close(fp)
+  end
+
+  test "removing a file" do
+    {:ok, _} = Vaporator.CloudFs.file_upload(
+      @dbx, "./remove-test.txt", "/vaporator/test/remove-test.txt"
+    )
+    
+    {:ok, meta} = Vaporator.CloudFs.file_remove(
+      @dbx, "/vaporator/test/remove-test.txt"
+    )
+
+    # Access protocol not available by default, must use dot access
+    assert meta.path == "/vaporator/test/remove-test.txt"
+    
+  end
+end

--- a/test/vaporator/dropbox_file_upload.exs
+++ b/test/vaporator/dropbox_file_upload.exs
@@ -1,4 +1,4 @@
-defmodule Vaporator.DropboxFileDownloadTest do
+defmodule Vaporator.DropboxFileUploadTest do
   use ExUnit.Case
 
   @dbx %Vaporator.Dropbox{access_token: System.get_env("DROPBOX_ACCESS_TOKEN")}


### PR DESCRIPTION
Implements CloudFs.file_remove for Dropbox (issue #10). 

Made a few other edits:

- Added `process_bad_response` for use by both `process_json_response` and `process_download_response` to handle bad status codes (400..599) and unknown, as well as detection of "path not found" errors 
- Added :path_not_found signal for bad responses so this can be caught and reported
- Refactored encoding of body Map from Dropbox's CloudFs `impl` to  the `post_api` function, in order to simplify `impl` development (no point in repeatedly calling `Poison.encode` in the `impl` when it's necessary for all JSON API calls)’
- Added better signaling throughout (everything returns an `{:ok, ...}` or `{:error, ...}`

Still needs testing.