### PR TITLE
Dropbox file update

### DIFF
--- a/lib/vaporator/cloud.ex
+++ b/lib/vaporator/cloud.ex
@@ -80,6 +80,9 @@ defprotocol Vaporator.CloudFs do
   # Need to be able to upload binary content of a file on the local
   # file system to a particular path on the cloud file system.
   # 
+  # The file should always be transferred and should overwrite
+  # whatever is (might be) already there.
+  # 
   # Args:
   # - fs (Vaporator.CloudFs impl): Cloud file system
   # - local_path (binary): Path of file on local file system to upload
@@ -90,12 +93,40 @@ defprotocol Vaporator.CloudFs do
   #     underlying subsystem. 
   # 
   # Returns:
-  #   {:ok, Vaporator.CloudFs.FileContent}
+  #   {:ok, Vaporator.CloudFs.Meta}
   #     or
+  #   {:error, {:bad_decode, decode error (any)}
+  #     or 
   #   {:error, {:bad_status, {:status_code, code (int)}, JSON (Map)}}
   #     or 
   #   {:error, {:unhandled_status, {:status_code, code (int)}, body (binary)}}
   def file_upload(fs, local_path, fs_path, args \\ %{})
+
+  # Need to be able to update binary content of a file on the cloud
+  # file system to the version on the local file system.
+  #
+  # In the case of file_upload, the file is always transferred. In the
+  # case of file_update, the file transfer only happens if the cloud
+  # content is different from the local content.
+  # 
+  # Args:
+  # - fs (Vaporator.CloudFs impl): Cloud file system
+  # - local_path (binary): Path of file on local file system to upload
+  # - fs_path (binary): Path on cloud file system to place uploaded
+  #     content. If this path ends with a "/" then it should be
+  #     treated as a directory in which to place the local_path
+  # - args (Map): File-system-specific arguments to pass to the
+  #     underlying subsystem. 
+  # 
+  # Returns:
+  #   {:ok, Vaporator.CloudFs.Meta}
+  #     or
+  #   {:error, {:bad_decode, decode error (any)}
+  #     or 
+  #   {:error, {:bad_status, {:status_code, code (int)}, JSON (Map)}}
+  #     or 
+  #   {:error, {:unhandled_status, {:status_code, code (int)}, body (binary)}}
+  def file_update(fs, local_path, fs_path, args \\ %{})
 
   # Need to be able to remove a file or folder on the cloud file
   # system.

--- a/test/vaporator/dropbox/dropbox_file_update.exs
+++ b/test/vaporator/dropbox/dropbox_file_update.exs
@@ -1,0 +1,41 @@
+defmodule Vaporator.DropboxFileUpdateTest do
+  use ExUnit.Case
+
+  @dbx %Vaporator.Dropbox{access_token: System.get_env("DROPBOX_ACCESS_TOKEN")}
+
+  test "Dropbox hash function" do
+    File.write("./dbx-hash-test.txt", "test data")
+    assert Vaporator.Dropbox.dbx_hash!(
+      "./dbx-hash-test.txt"
+    ) == "824979ede959fefe53082bc14502f8bf041d53997ffb65cbbe3ade5803f7fb76"
+  end
+
+  test "update a file" do
+    # First, create and upload the file
+    File.write("./update-test.txt", "update test data")
+    {:ok, meta} = Vaporator.CloudFs.file_upload(
+      @dbx, "./update-test.txt", "/vaporator/test/update-test.txt"
+    )
+
+    assert meta.path == "/vaporator/test/update-test.txt"
+    assert meta.meta["content_hash"] == "6eec1c708f7d1962bd125e2148e4b8580230d7b1ab1e810a048b10575f89edbe"
+    server_modified = meta.meta["server_modified"]
+    
+    {:ok, meta} = Vaporator.CloudFs.file_update(
+      @dbx, "./update-test.txt", "/vaporator/test/update-test.txt"
+    )
+    assert meta.path == "/vaporator/test/update-test.txt"
+    assert meta.meta["content_hash"] == "6eec1c708f7d1962bd125e2148e4b8580230d7b1ab1e810a048b10575f89edbe"
+    assert meta.meta["server_modified"] == server_modified
+
+
+    File.write("./update-test.txt", "different test data")
+    {:ok, meta} = Vaporator.CloudFs.file_update(
+      @dbx, "./update-test.txt", "/vaporator/test/update-test.txt"
+    )
+    assert meta.path == "/vaporator/test/update-test.txt"
+    assert meta.meta["content_hash"] == "5b81988c6b0a3d4a95edf8cf5c505e1410286dbff0c6d9201de80872981eabf9"
+    assert meta.meta["server_modified"] != server_modified
+    
+  end
+end

--- a/test/vaporator/dropbox/fs_ops_test.exs
+++ b/test/vaporator/dropbox/fs_ops_test.exs
@@ -34,7 +34,7 @@ defmodule Vaporator.DropboxFsOpsTest do
 
   test "get_metadata from dropbox folder that exists" do
     use_cassette "cloudfs/get_metadata/folder" do
-      meta = Vaporator.CloudFs.get_metadata(
+      {:ok, meta} = Vaporator.CloudFs.get_metadata(
         @dbx,
         @test_dir
       )
@@ -44,7 +44,7 @@ defmodule Vaporator.DropboxFsOpsTest do
 
   test "get_metadata from dropbox file that exists" do
     use_cassette "cloudfs/get_metadata/file" do
-      meta = Vaporator.CloudFs.get_metadata(
+      {:ok, meta} = Vaporator.CloudFs.get_metadata(
         @dbx,
         @test_file_path
       )


### PR DESCRIPTION
- Fixes to CloudFs protocol documentation
- Refactored Dropbox CloudFs `impl` to put operant code inside Dropbox, and reference that from the `impl`
- Added `file_update` to both CloudFs protocol and Dropbox implementation (issue #11)
- Fixed `get_metadata` to return `{:ok, meta}` Tuple