### PR TITLE
list_folder_pagination

### DIFF
--- a/lib/vaporator/application.ex
+++ b/lib/vaporator/application.ex
@@ -15,11 +15,9 @@ defmodule Vaporator do
   use Application
   require Logger
 
-  def start(type, args) do
+  def start(_type, _args) do
     Logger.info(
       "#{__MODULE__} starting...\n" <>
-        "  type: #{type}\n" <>
-        "  args: #{args}\n" <>
         "  env: #{Mix.env}"
     )
 

--- a/lib/vaporator/application.ex
+++ b/lib/vaporator/application.ex
@@ -15,7 +15,7 @@ defmodule Vaporator do
   use Application
   require Logger
 
-  def start(_type, _args) do
+  def start(type, args) do
     Logger.info(
       "#{__MODULE__} starting...\n" <>
         "  type: #{type}\n" <>

--- a/lib/vaporator/clientfs/clientfs.ex
+++ b/lib/vaporator/clientfs/clientfs.ex
@@ -124,7 +124,6 @@ defmodule Vaporator.ClientFs do
     sync_dirs (list): List of absolute paths to directories
   """
   def sync_dirs do
-    Logger.info("#{__MODULE__} getting sync_dirs")
 
     case Application.get_env(:vaporator, :clientfs_sync_dirs) do
       nil ->
@@ -132,7 +131,6 @@ defmodule Vaporator.ClientFs do
         []
 
       dirs ->
-        Logger.info("#{__MODULE__} sync_dirs set: #{dirs}")
         dirs
     end
   end

--- a/lib/vaporator/clientfs/event_monitor/monitor.ex
+++ b/lib/vaporator/clientfs/event_monitor/monitor.ex
@@ -36,7 +36,7 @@ defmodule Vaporator.ClientFs.EventMonitor do
         "  paths: #{paths}"
     )
 
-    monitor(paths)
+    GenServer.cast({:monitor, paths})
     {:ok, paths}
   end
 
@@ -165,6 +165,10 @@ defmodule Vaporator.ClientFs.EventMonitor do
     {:ok, @cloudfs_root}
 
     Logger.info("#{__MODULE__} COMPLETED cloudfs cache of '#{@cloudfs_root}'")
+  end
+
+  def handle_cast({:monitor, paths}, state) do
+    {:noreply, monitor(paths), state}
   end
 
 end

--- a/lib/vaporator/clientfs/event_monitor/monitor.ex
+++ b/lib/vaporator/clientfs/event_monitor/monitor.ex
@@ -36,6 +36,7 @@ defmodule Vaporator.ClientFs.EventMonitor do
         "  paths: #{paths}"
     )
 
+    # Added to ensure module finishes initialization
     GenServer.cast(__MODULE__, {:monitor, paths})
     {:ok, paths}
   end
@@ -167,6 +168,9 @@ defmodule Vaporator.ClientFs.EventMonitor do
     Logger.info("#{__MODULE__} COMPLETED cloudfs cache of '#{@cloudfs_root}'")
   end
 
+  @doc """
+  Starts the monitoring process
+  """
   def handle_cast({:monitor, paths}, state) do
     {:noreply, monitor(paths), state}
   end

--- a/lib/vaporator/clientfs/event_monitor/monitor.ex
+++ b/lib/vaporator/clientfs/event_monitor/monitor.ex
@@ -36,7 +36,7 @@ defmodule Vaporator.ClientFs.EventMonitor do
         "  paths: #{paths}"
     )
 
-    GenServer.cast({:monitor, paths})
+    GenServer.cast(__MODULE__, {:monitor, paths})
     {:ok, paths}
   end
 

--- a/lib/vaporator/cloudfs/providers/dropbox.ex
+++ b/lib/vaporator/cloudfs/providers/dropbox.ex
@@ -359,7 +359,7 @@ defmodule Vaporator.Dropbox do
         list_folder(
           dbx,
           result_meta,
-          Map.take(result_meta, ["has_more"])
+          Map.take(result_meta, ["has_more"]),
           [entries | results]
         )
     end

--- a/lib/vaporator/cloudfs/providers/dropbox.ex
+++ b/lib/vaporator/cloudfs/providers/dropbox.ex
@@ -335,7 +335,7 @@ defmodule Vaporator.Dropbox do
         list_folder(
           dbx,
           result_meta,
-          Map.take(result_meta, "has_more"),
+          Map.take(result_meta, ["has_more"]),
           entries
         )
 

--- a/lib/vaporator/cloudfs/providers/dropbox.ex
+++ b/lib/vaporator/cloudfs/providers/dropbox.ex
@@ -349,7 +349,7 @@ defmodule Vaporator.Dropbox do
   end
 
   defp list_folder(
-    dbx, result_meta, %{"has_more" => "true"}, results
+    dbx, result_meta, %{"has_more" => true}, results
   ) do
 
     body = Map.take(result_meta, ["cursor"])
@@ -362,11 +362,14 @@ defmodule Vaporator.Dropbox do
           Map.take(result_meta, ["has_more"]),
           [entries | results]
         )
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 
   defp list_folder(
-    _, result_meta, %{"has_more" => "false"}, results
+    _, result_meta, %{"has_more" => false}, results
   ) do
     results = 
       [result_meta["entries"] | results]

--- a/lib/vaporator/cloudfs/providers/dropbox.ex
+++ b/lib/vaporator/cloudfs/providers/dropbox.ex
@@ -327,6 +327,19 @@ defmodule Vaporator.Dropbox do
     end
   end
 
+  @doc """
+  Lists the contents of a directory on CloudFs.
+
+  Supports recursive by passing %{recursive: true} in args
+
+  Args:
+    dbx (struct): Specifies CloudFs provider and access token
+    path (binary): CloudFs root directory
+    args (map): additional arguments to be passed in the body
+
+  Returns:
+    CloudFs.ResultsMeta (struct): all files and folders found in directory
+  """
   def list_folder(dbx, path, args \\ %{}) do
     body = Map.merge(%{:path => prep_path(path)}, args)
 

--- a/lib/vaporator/cloudfs/providers/dropbox.ex
+++ b/lib/vaporator/cloudfs/providers/dropbox.ex
@@ -356,7 +356,12 @@ defmodule Vaporator.Dropbox do
 
     case post_api(dbx, "/files/list_folder/continue", body) do
       {:ok, result_meta = %{"entries" => entries}} ->
-        list_folder(dbx, result_meta, [entries | results])
+        list_folder(
+          dbx,
+          result_meta,
+          Map.take(result_meta, ["has_more"])
+          [entries | results]
+        )
     end
   end
 

--- a/lib/vaporator/cloudfs/providers/dropbox.ex
+++ b/lib/vaporator/cloudfs/providers/dropbox.ex
@@ -352,7 +352,7 @@ defmodule Vaporator.Dropbox do
     dbx, result_meta, %{"has_more" => "true"}, results
   ) do
 
-    body = Map.take(result_meta, "cursor")
+    body = Map.take(result_meta, ["cursor"])
 
     case post_api(dbx, "/files/list_folder/continue", body) do
       {:ok, result_meta = %{"entries" => entries}} ->
@@ -361,7 +361,7 @@ defmodule Vaporator.Dropbox do
   end
 
   defp list_folder(
-    _, result_meta, %{"has_more" => "true"}, results
+    _, result_meta, %{"has_more" => "false"}, results
   ) do
     results = 
       [result_meta["entries"] | results]

--- a/lib/vaporator/cloudfs/providers/dropbox.ex
+++ b/lib/vaporator/cloudfs/providers/dropbox.ex
@@ -10,6 +10,8 @@ defmodule Vaporator.Dropbox do
   - Better, more descriptive error messaging/routing
   """
 
+  alias Vaporator.CloudFs
+
   @enforce_keys [:access_token]
   defstruct [:access_token]
 
@@ -260,7 +262,7 @@ defmodule Vaporator.Dropbox do
         body: body,
         headers: headers
       }) do
-    {:ok, %Vaporator.CloudFs.FileContent{content: body, headers: headers}}
+    {:ok, %CloudFs.FileContent{content: body, headers: headers}}
   end
 
   def process_download_response(response) do
@@ -272,7 +274,7 @@ defmodule Vaporator.Dropbox do
   Vaporator.CloudFs.Meta element
   """
   def dropbox_meta_to_cloudfs(meta) do
-    %Vaporator.CloudFs.Meta{
+    %CloudFs.Meta{
       meta: meta,
       type: meta |> Map.get(".tag", "none") |> String.to_atom(),
       name: meta["name"],
@@ -330,12 +332,12 @@ defmodule Vaporator.Dropbox do
 
     case post_api(dbx, "/files/list_folder", body) do
       {:ok, result_meta = %{"entries" => entries}} when entries != [] ->
-        results =
-          for meta <- entries do
-            dropbox_meta_to_cloudfs(meta)
-          end
-
-        {:ok, %Vaporator.CloudFs.ResultsMeta{results: results, meta: result_meta}}
+        list_folder(
+          dbx,
+          result_meta,
+          Map.take(result_meta, "has_more"),
+          entries
+        )
 
       {:ok, _} ->
         Logger.error("No entries listed in response object")
@@ -344,6 +346,29 @@ defmodule Vaporator.Dropbox do
       {:error, error} ->
         {:error, error}
     end
+  end
+
+  defp list_folder(
+    dbx, result_meta, %{"has_more" => "true"}, results
+  ) do
+
+    body = Map.take(result_meta, "cursor")
+
+    case post_api(dbx, "/files/list_folder/continue", body) do
+      {:ok, result_meta = %{"entries" => entries}} ->
+        list_folder(dbx, result_meta, [entries | results])
+    end
+  end
+
+  defp list_folder(
+    _, result_meta, %{"has_more" => "true"}, results
+  ) do
+    results = 
+      [result_meta["entries"] | results]
+      |> List.flatten()
+      |> Enum.map(&dropbox_meta_to_cloudfs/1)
+
+    {:ok, %CloudFs.ResultsMeta{results: results, meta: result_meta}}
   end
 
   def file_download(dbx, path, dbx_api_args \\ %{}) do

--- a/test/vaporator/clientfs/event_pipeline/consumer_test.exs
+++ b/test/vaporator/clientfs/event_pipeline/consumer_test.exs
@@ -2,20 +2,15 @@ defmodule Vaporator.ClientFs.EventConsumerTest do
   use ExUnit.Case, async: false
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
+  alias Vaporator.ClientFs.EventConsumer
+
   @cloudfs %Vaporator.Dropbox{
     access_token: Application.get_env(:vaporator, :dbx_token)
   }
   @cloudfs_root Application.get_env(:vaporator, :cloudfs_root)
 
   setup_all do 
-    Vaporator.ClientFs.EventProducer.start_link()
-
-    # If the Application callback line in mix.exs is commented out,
-    # this works. If it is uncommented (i.e. if the Application is
-    # allowed to start prior to testing), then this fails with:
-    #
-    # ** (MatchError) no match of right hand side value: {:error, {:already_started, #PID<0.331.0>}}
-    {:ok, consumer_pid} = Vaporator.ClientFs.EventConsumer.start_link()
+    consumer_pid = Process.whereis(EventConsumer)
     Process.monitor(consumer_pid)
     :ok
   end


### PR DESCRIPTION
Closes #33 

### ClientFs.EventMonitor

- Updated init function to use a cast for starting the monitor recursive process.  This makes sure the entire application does not crash when EventMonitor fails for some reason.

- Added 2 private functions for list_folder that recursively handles pagination when `%{"has_more" => true}` in the api response.  This is done by using the returned `cursor` with the `/list_folder/continue` endpint to retrieve the next set of results.  The public function interface did not change and is handled internally in the Dropbox module.

Also, I resolved the issues causing unit tests to fail.  They are all able to run with the application started now.